### PR TITLE
管理者と投稿を紐付け

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -11,14 +11,14 @@ class Admin::PostsController < ApplicationController
   end
 
   def new
-    @post = Post.new
+    @post = current_admin_user.posts.new
   end
 
   def edit
   end
 
   def create
-    @post = Post.new(post_params)
+    @post = current_admin_user.posts.new(post_params)
 
     if @post.save
       redirect_to admin_posts_path, flash: { success: create_flash_message('success', 'create', @post, :title) }

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class AdminUser < ApplicationRecord
-  # 使わないやつ→ :registerable, :confirmable, :lockable, :timeoutable, :omniauthable, :recoverable
+  # :registerable, :confirmable, :lockable, :timeoutable, :omniauthable, :recoverable
   # https://qiita.com/cigalecigales/items/73d7bd7ec59a001ccd74
   devise :database_authenticatable, :rememberable, :validatable, :trackable
+
+  has_many :posts, dependent: :delete_all
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,8 +3,10 @@
 class Post < ApplicationRecord
   mount_uploader :eyecatch, EyecatchUploader # eyecatchカラムとcarrierwaveのuploaderを紐付け
 
+  belongs_to :admin_user, optional: true
   belongs_to :category, optional: true # 関連先のモデルのvalidationも実行してるらしいので、optional: trueで無効化
 
+  validates :admin_user, presence: true
   validates :category, presence: true
   validates :title, presence: true
   validates :content, presence: true

--- a/app/views/admin/posts/index.html.slim
+++ b/app/views/admin/posts/index.html.slim
@@ -5,9 +5,10 @@ table.table.table-bordered.table-hover#post-table
     tr
       th style='width: 10%' = Post.human_attribute_name(:eyecatch)
       th style='width: 10%' = Post.human_attribute_name(:category)
-      th style='width: 26%' = Post.human_attribute_name(:title)
-      th style='width: 26%' = Post.human_attribute_name(:published)
-      th style='width: 26%' = I18n.t('words.action')
+      th style='width: 20%' = Post.human_attribute_name(:title)
+      th style='width: 20%' = I18n.t('words.author')
+      th style='width: 20%' = Post.human_attribute_name(:published)
+      th style='width: 20%' = I18n.t('words.action')
   tbody
     - @posts.each do |post|
       tr
@@ -16,6 +17,7 @@ table.table.table-bordered.table-hover#post-table
             = image_tag post.eyecatch.url(:crop_image), class: 'crop__image'
         td = post.category.name
         td = post.title
+        td = post.admin_user.email
         td
           span class="badge badge-#{post.published ? 'primary' : 'danger'}" = I18n.t("boolean.post.published.#{post.published}").capitalize
         td

--- a/config/locales/custom/ja.yml
+++ b/config/locales/custom/ja.yml
@@ -22,6 +22,7 @@ ja:
     insert_image: 画像を挿入
     manage: "%{obj}管理"
     back: 戻る
+    author: 著者
   flash:
     default:
       success: "%{obj}を%{action}しました"

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -8,11 +8,12 @@ ja:
       admin_user: 管理者
     attributes:
       post:
+        admin_user: 管理者
         category: カテゴリ
         title: タイトル
         content: 本文
         eyecatch: アイキャッチ
-        published: 公開
+        published: 公開状況
       photo:
         image: 画像
       category:
@@ -24,5 +25,5 @@ ja:
   boolean:
     post:
       published:
-        true: 'public'
-        false: 'private'
+        true: '公開'
+        false: '非公開'

--- a/db/migrate/20190324063403_devise_create_admin_users.rb
+++ b/db/migrate/20190324063403_devise_create_admin_users.rb
@@ -5,8 +5,6 @@ class DeviseCreateAdminUsers < ActiveRecord::Migration[5.2]
     create_table :admin_users do |t|
       t.string :email, null: false, default: ''
       t.string :encrypted_password, null: false, default: ''
-      t.string :reset_password_token
-      t.datetime :reset_password_sent_at
       t.datetime :remember_created_at
       t.integer :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at

--- a/db/migrate/20190329125219_add_admin_user_id_to_post.rb
+++ b/db/migrate/20190329125219_add_admin_user_id_to_post.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdminUserIdToPost < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :admin_user_id, :integer, after: :id, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,12 +12,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_324_063_403) do
+ActiveRecord::Schema.define(version: 20_190_329_125_219) do
   create_table 'admin_users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
     t.string 'email', default: '', null: false
     t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
     t.datetime 'remember_created_at'
     t.integer 'sign_in_count', default: 0, null: false
     t.datetime 'current_sign_in_at'
@@ -43,6 +41,7 @@ ActiveRecord::Schema.define(version: 20_190_324_063_403) do
   end
 
   create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.integer 'admin_user_id', null: false
     t.integer 'category_id', default: 0, null: false
     t.string 'title', null: false
     t.text 'content', null: false


### PR DESCRIPTION
Close #20 

### 実装内容
- Postモデルにadmin_user_idカラムを追加
- PostモデルとAdminUserモデルを紐付け
- postコントローラとビューの修正
- i18n設定