### PR TITLE
トップページのUI改良

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,8 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  # gem 'spring' # フリーズするので使わない
-  # gem 'spring-watcher-listen', '~> 2.0.0' # フリーズするので使わない
+  # gem 'spring'
+  # gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do
@@ -71,5 +71,6 @@ gem 'devise'
 gem 'font-awesome-sass'
 gem 'html2slim'
 gem 'jquery-rails'
+gem 'kaminari'
 gem 'rmagick' # 画像リサイズ
 gem 'slim-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -280,6 +292,7 @@ DEPENDENCIES
   html2slim
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-byebug

--- a/app/assets/stylesheets/modules/post.scss
+++ b/app/assets/stylesheets/modules/post.scss
@@ -1,0 +1,5 @@
+.post-pagination {
+  nav.pagination {
+    display: initial !important;
+  }
+}

--- a/app/assets/stylesheets/modules/top.scss
+++ b/app/assets/stylesheets/modules/top.scss
@@ -13,6 +13,12 @@
 }
 
 
-.category-menu {
+.categoryMenu {
   border-right: 1px solid rgba(0,0,0,.125);
+
+  &__item {
+    &--active {
+      background-color: #f5f5f5;
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/top.scss
+++ b/app/assets/stylesheets/modules/top.scss
@@ -22,3 +22,12 @@
     }
   }
 }
+
+.navbar-toggler {
+  top: 0.5rem;
+  left: 1rem;
+}
+
+.header {
+  padding: 0.5rem 1rem;
+}

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -7,7 +7,7 @@ class Admin::PostsController < ApplicationController
   before_action :authenticate_admin_user!
 
   def index
-    @posts = Post.all
+    @posts = Post.all.order(created_at: :desc).page(params[:page]).per(6)
   end
 
   def new

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -3,6 +3,6 @@
 class TopController < ApplicationController
   def index
     @categories = Category.all
-    @posts = Post.where(published: true).order(created_at: :desc)
+    @posts = Post.where(published: true).order(created_at: :desc).page(params[:page]).per(3)
   end
 end

--- a/app/views/admin/posts/index.html.slim
+++ b/app/views/admin/posts/index.html.slim
@@ -25,3 +25,5 @@ table.table.table-bordered.table-hover#post-table
           = link_to admin_post_path(post), method: :delete, data: { confirm: I18n.t('dialog', obj: post.title, action: I18n.t('actions.default.destroy')) }
             = icon 'far', 'trash-alt'
             = I18n.t('actions.default.destroy')
+.post-pagination
+  center = paginate @posts

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "First" page
+  - available local variables
+    url          : url to the first page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.first
+  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,9 @@
+/ Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.page.gap
+  == t('views.pagination.truncate').html_safe
+'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Last" page
+  - available local variables
+    url          : url to the last page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.last
+  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Next" page
+  - available local variables
+    url          : url to the next page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.next
+  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,11 @@
+/ Link showing page number
+  - available local variables
+    page         : a page object for "this" page
+    url          : url to this page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span class="page#{' current' if page.current?}"
+  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,19 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination
+    == first_page_tag unless current_page.first?
+    == prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        == page_tag page
+      - elsif !page.was_truncated?
+        == gap_tag
+    == next_page_tag unless current_page.last?
+    == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Previous" page
+  - available local variables
+    url          : url to the previous page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.prev
+  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,12 +11,12 @@ html
     .container.mb-3
       .row
         .col-xl-10.offset-xl-1.row
-          .col-lg-2.col-xl-2.d-none.d-lg-block.category-menu.pr-0
+          .col-lg-2.col-xl-2.d-none.d-lg-block.categoryMenu.pr-0
             .py-2.pl-3.mb-0.font-weight-bold = Category.model_name.human
-            = link_to root_path, class: 'category-menu__item pl-3 py-2 d-block text-dark no-underline'
+            = link_to root_path, class: "categoryMenu__item pl-3 py-2 d-block text-dark no-underline #{'categoryMenu__item--active' if request.path == root_path}"
               | Home
             - @categories.each do |category|
-              = link_to root_path, class: 'category-menu__item pl-3 py-2 d-block text-dark no-underline'
+              = link_to root_path, class: 'categoryMenu__item pl-3 py-2 d-block text-dark no-underline'
                 = category.name
           .col-12.col-lg-10.col-xl-10.top-content
             = yield

--- a/app/views/top/_header.html.slim
+++ b/app/views/top/_header.html.slim
@@ -1,9 +1,12 @@
-nav.navbar.navbar-expand-lg.navbar-light.bg-light
-  a.navbar-brand href="#"  Media
-  button.navbar-toggler aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
+.header.navbar-expand-lg.navbar-light.bg-light
+  center
+    a.navbar-brand href="#" Media
+  button.navbar-toggler.position-absolute aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
   #navbarSupportedContent.collapse.navbar-collapse
     ul.navbar-nav.mr-auto.d-lg-none
+      li.nav-item
+        = link_to 'Home', root_path, class: 'nav-link'
       - @categories.each do |category|
         li.nav-item
-          a.nav-link href="#"  = category.name
+          a.nav-link href="#" = category.name

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -12,3 +12,7 @@ h4.text-center.mt-3 -- 新着記事 --
               = post.category.name
               br
               = I18n.l(post.created_at.to_date, format: :default)
+.row
+  .col-12
+    .post-pagination
+      center = paginate @posts

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Kaminari.configure do |config|
   # config.default_per_page = 25
   # config.max_per_page = nil

--- a/config/locales/kaminari/ja.yml
+++ b/config/locales/kaminari/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: '&laquo;'
+      last: '&raquo;'
+      previous: '&lsaquo;'
+      next: '&rsaquo;'
+      truncate: '&hellip;'
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name}がありません"
+          one: "1件の%{entry_name}が表示されています"
+          other: "%{count}件数の%{entry_name}が表示されています"
+      more_pages:
+        display_entries: "全%{total}件中%{first}&nbsp;-&nbsp;%{last}件の%{entry_name}が表示されています"


### PR DESCRIPTION
close #29 
- `kaminari`インストール
- i18n設定&kaminari view導入
- 管理画面とトップページの記事一覧にページネーション設置
- トップページヘッダーのデザイン修正(MERYを意識したもの)